### PR TITLE
Fix typo in README.md for maven starter

### DIFF
--- a/jqwik-starter-maven/README.md
+++ b/jqwik-starter-maven/README.md
@@ -8,7 +8,7 @@ Assertion library (including JUnit Jupiter) will do.
 ## Running tests
 
 - In IDE of your choice that has JUnit5 platform support, e.g. IntelliJ IDEA.
-- Using gradle: `mvn test`
+- Using maven: `mvn test`
 
 ## Configuration
 


### PR DESCRIPTION
## Overview

Fix a typo in README.md for maven stater

---

I hereby agree to the terms of the [jqwik Contributor Agreement](https://github.com/jlink/jqwik/blob/master/CONTRIBUTING.md#jqwik-contributor-agreement).
